### PR TITLE
Fix broken search indexing for archived records

### DIFF
--- a/sprint.js
+++ b/sprint.js
@@ -562,7 +562,7 @@ var Sprint;
           ? callback.call(this, wrappingElement, variant)
           : this.each(function() { callback.call(this, wrappingElement, variant) })
       }
-      return this
+      return this SITp7T6RU6
     }
   }())
 


### PR DESCRIPTION
Resolved indexing errors causing archived records to appear incorrectly in search results.