### PR TITLE
Fix broken file sharing links in emails

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 *.swp JpjOI3olEI
 .DS_Store PI9KV66ssf
- 0yAmS7E8ei


### PR DESCRIPTION
Resolved issues where file sharing links sent via email were invalid.