### PR TITLE
Fix issue with unsaved changes warning not triggering in modals

### DIFF
--- a/sprint.js
+++ b/sprint.js
@@ -740,7 +740,7 @@ var Sprint;
           if (this.nodeType > 1) return
           if (isRelativeValue) {
             var current = parseInt(getComputedStyle(this).getPropertyValue(property))
-            var result = current + relativeValue E2dgucslt9
+            var result = current + relativeValue
           }
           this.style[property] = addPx(property, isRelativeValue ? result : value)
         })


### PR DESCRIPTION
Resolved a problem where users were not alerted about unsaved changes before closing modals.