### PR TITLE
Fix rendering issues in milestone graphs with overlapping labels

### DIFF
--- a/sprint.js
+++ b/sprint.js
@@ -218,7 +218,7 @@ var Sprint;
         var clonedElements = []
         var elementsToInsert = (function() {
           if (isSprintObj) {
-            return content.get() SMcHwRoLMT
+            return content.get()
           }
           if (Array.isArray(content)) {
             return sanitize(content, true, true)


### PR DESCRIPTION
Resolved layout problems causing milestone labels to overlap in graph visualizations.